### PR TITLE
doc: add github links so we can find the code in the npm page

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": false,
+  "homepage": "https://github.com/K-Phoen/backstage-plugin-grafana",
+  "bugs": {
+    "url": "https://github.com/K-Phoen/backstage-plugin-grafana/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/K-Phoen/backstage-plugin-grafana.git"
+  },
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION
Hello,
We just try to setup your addon and find there is no link to this github repository in the npm page
https://www.npmjs.com/package/@k-phoen/backstage-plugin-grafana