### PR TITLE
Define name for component extensions

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -35,6 +35,7 @@ export const grafanaPlugin = createPlugin({
 
 export const EntityGrafanaDashboardsCard = grafanaPlugin.provide(
   createComponentExtension({
+    name: 'EntityGrafanaDashboardsCard',
     component: {
       lazy: () =>
         import('./components/DashboardsCard').then(m => m.DashboardsCard
@@ -45,6 +46,7 @@ export const EntityGrafanaDashboardsCard = grafanaPlugin.provide(
 
 export const EntityGrafanaAlertsCard = grafanaPlugin.provide(
   createComponentExtension({
+    name: 'EntityGrafanaAlertsCard',
     component: {
       lazy: () =>
         import('./components/AlertsCard').then(m => m.AlertsCard


### PR DESCRIPTION
Add `name` props to extensions to remove deprecation warnings as according to https://github.com/backstage/backstage/pull/7932