### PR TITLE
Customize tables for dashboard & alerts

### DIFF
--- a/src/components/AlertsCard/AlertsCard.test.tsx
+++ b/src/components/AlertsCard/AlertsCard.test.tsx
@@ -20,7 +20,7 @@ import { AlertsTable } from './AlertsCard';
 
 describe('AlertsTable', () => {
   it('should render even with no alerts', async () => {
-    const rendered = render(<AlertsTable title="alerts" showState alerts={[]} />);
+    const rendered = render(<AlertsTable opts={{title: "alerts", showState: true}} alerts={[]} />);
 
     expect(await rendered.findByText('No records to display')).toBeInTheDocument();
   });

--- a/src/components/AlertsCard/AlertsCard.tsx
+++ b/src/components/AlertsCard/AlertsCard.tsx
@@ -55,14 +55,8 @@ const AlertStatusBadge = ({ alert }: { alert: GrafanaAlert }) => {
 export const AlertsTable = ({alerts, opts}: {alerts: GrafanaAlert[], opts: AlertsCardOpts}) => {
   const columns: TableColumn<GrafanaAlert>[] = [
     {
-      title: 'id',
-      field: 'name',
-      hidden: true,
-      searchable: true,
-      render: (row: GrafanaAlert): string => row.name,
-    },
-    {
       title: 'Name',
+      field: 'name',
       cellStyle: {width: '90%'},
       render: (row: GrafanaAlert): React.ReactNode => <Link href={row.url} target="_blank" rel="noopener">{row.name}</Link>,
     },
@@ -83,7 +77,7 @@ export const AlertsTable = ({alerts, opts}: {alerts: GrafanaAlert[], opts: Alert
         pageSize: opts.pageSize ?? 5,
         search: opts.searchable ?? false,
         emptyRowsWhenPaging: false,
-        sorting: false,
+        sorting: opts.sortable ?? false,
         draggable: false,
         padding: 'dense',
       }}
@@ -114,6 +108,7 @@ export type AlertsCardOpts = {
   paged?: boolean;
   searchable?: boolean;
   pageSize?: number;
+  sortable?: boolean;
   title?: string;
   showState?: boolean;
 };
@@ -131,5 +126,7 @@ export const AlertsCard = (opts?: AlertsCardOpts) => {
     return <MissingAnnotationEmptyState annotation={GRAFANA_ANNOTATION_ALERT_LABEL_SELECTOR} />;
   }
 
-  return <Alerts entity={entity} opts={opts || {}} />;
+  const finalOpts = {...opts, ...{showState: opts?.showState && !unifiedAlertingEnabled}};
+
+  return <Alerts entity={entity} opts={finalOpts} />;
 };

--- a/src/components/DashboardsCard/DashboardsCard.test.tsx
+++ b/src/components/DashboardsCard/DashboardsCard.test.tsx
@@ -35,7 +35,7 @@ describe('DashboardsTable', () => {
   }
 
   it('should render even with no dashboards', async () => {
-    const rendered = render(<DashboardsTable dashboards={[]} entity={entityMock} />);
+    const rendered = render(<DashboardsTable dashboards={[]} entity={entityMock} opts={{}} />);
 
     expect(await rendered.findByText('No records to display')).toBeInTheDocument();
   });

--- a/src/components/DashboardsCard/DashboardsCard.tsx
+++ b/src/components/DashboardsCard/DashboardsCard.tsx
@@ -29,18 +29,13 @@ import { GRAFANA_ANNOTATION_TAG_SELECTOR, isDashboardSelectorAvailable, tagSelec
 export const DashboardsTable = ({entity, dashboards, opts}: {entity: Entity, dashboards: Dashboard[], opts: DashboardCardOpts}) => {
   const columns: TableColumn<Dashboard>[] = [
     {
-      title: 'id',
-      field: 'title',
-      hidden: true,
-      searchable: true,
-      render: (row: Dashboard): string => row.title,
-    },
-    {
       title: 'Title',
+      field: 'title',
       render: (row: Dashboard) => <Link href={row.url} target="_blank" rel="noopener">{row.title}</Link>,
     },
     {
       title: 'Folder',
+      field: 'folderTitle',
       render: (row: Dashboard) => <Link href={row.folderUrl} target="_blank" rel="noopener">{row.folderTitle}</Link>,
     },
   ];
@@ -59,7 +54,7 @@ export const DashboardsTable = ({entity, dashboards, opts}: {entity: Entity, das
         pageSize: opts.pageSize ?? 5,
         search: opts.searchable ?? false,
         emptyRowsWhenPaging: false,
-        sorting: false,
+        sorting: opts.sortable ?? false,
         draggable: false,
         padding: 'dense',
       }}
@@ -69,7 +64,7 @@ export const DashboardsTable = ({entity, dashboards, opts}: {entity: Entity, das
   );
 };
 
-const Dashboards = ({entity, opts}: {entity: Entity, opts?: DashboardCardOpts}) => {
+const Dashboards = ({entity, opts}: {entity: Entity, opts: DashboardCardOpts}) => {
   const grafanaApi = useApi(grafanaApiRef);
   const { value, loading, error } = useAsync(async () => await grafanaApi.dashboardsByTag(tagSelectorFromEntity(entity)));
 
@@ -80,7 +75,7 @@ const Dashboards = ({entity, opts}: {entity: Entity, opts?: DashboardCardOpts}) 
   }
 
   return (
-    <DashboardsTable entity={entity} dashboards={value || []} opts={opts || {}} />
+    <DashboardsTable entity={entity} dashboards={value || []} opts={opts} />
   );
 };
 
@@ -88,6 +83,7 @@ export type DashboardCardOpts = {
   paged?: boolean;
   searchable?: boolean;
   pageSize?: number;
+  sortable?: boolean;
   title?: string;
 };
 
@@ -97,6 +93,6 @@ export const DashboardsCard = (opts?: DashboardCardOpts) => {
   return !isDashboardSelectorAvailable(entity) ? (
     <MissingAnnotationEmptyState annotation={GRAFANA_ANNOTATION_TAG_SELECTOR} />
   ) : (
-    <Dashboards entity={entity} opts={opts} />
+    <Dashboards entity={entity} opts={opts || {}} />
   );
 };


### PR DESCRIPTION
Signed-off-by: ivgo <ivgo@spreadgroup.com>

I have added a few new parameters so that the users can add extra functionalities using the backstage tables. 

Those new parameters will allow the users to customize the tables. First of all, it will be possible to allow the search, in order to work properly, I have also added a hidden field to search by the alert/dashboard name. Secondly, I added the possibility to use the paging and the pageSize if desired.

This is because in our case, the list was huge and the original tables were difficult to handle. With these 2 options, now we can have smaller tables and use the search as well, so looking for a dashboard and/or alert will be much easier.

If you need more information about it, just let me know.