### PR TITLE
Allow getting data from multiple tags

### DIFF
--- a/docs/alerts-on-component-page.md
+++ b/docs/alerts-on-component-page.md
@@ -46,6 +46,8 @@ annotations:
 
 The `EntityGrafanaAlertsCard` component will then display alerts matching the given label and value.
 
+It's also possible to add multiple comma-separated alert labels, like `service=awesome-service-1,service=awesome-service-2`, which will display alerts which have at least one of the given labels and values.
+
 ## With Grafana Legacy Alerting enabled
 
 If Grafana's [Unified Alerting](https://grafana.com/blog/2021/06/14/the-new-unified-alerting-system-for-grafana-everything-you-need-to-know/) is NOT enabled, alerts are selected by a tag present on the dashboards defining them:
@@ -56,3 +58,5 @@ annotations:
 ```
 
 The `EntityGrafanaAlertsCard` component will then display alerts matching the given tag.
+
+It's also possible to add multiple comma-separated tags, like `my-tag-1,my-tag-2`, which will display dashboards which have at least one of the tags.

--- a/docs/dashboards-on-component-page.md
+++ b/docs/dashboards-on-component-page.md
@@ -41,3 +41,5 @@ annotations:
 ```
 
 The `EntityGrafanaDashboardsCard` component will then display dashboards matching the given tag.
+
+It's also possible to add multiple comma-separated tags, like `my-tag-1,my-tag-2`, which will display dashboards which have at least one of the tags.


### PR DESCRIPTION
With this feature, now it's possible to fetch the alerts and dashboards for multiple tags.

This feature was also needed in our company, and it was rather simple to implement.

The idea is just adding a list of tags separated by commas. So instead of `my-tag`, now you can use `my-tag-1,my-tag-2`, and the API will make 2 requests to fetch all the information for both tags. Finally, I'm executing an extra check to remove duplicates, as a dashboard could have multiple tags and be fetched multiple times.

This change is small and should be easy to review, but if you need more data, please don't hesitate asking.