### PR TITLE
Export isAlertSelectorAvailable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@
 export { grafanaPlugin, EntityGrafanaDashboardsCard, EntityGrafanaAlertsCard } from './plugin';
 export {
   isDashboardSelectorAvailable,
+  isAlertSelectorAvailable,
   alertSelectorFromEntity,
   GRAFANA_ANNOTATION_ALERT_LABEL_SELECTOR,
   GRAFANA_ANNOTATION_TAG_SELECTOR,


### PR DESCRIPTION
In addition to `isDashboardSelectorAvailable`, it would be great to export `isAlertSelectorAvailable` as well.

## Why?

This allows the usage of `EntitySwitch` on the EntityPage. Instead of throwing an error, if there are not Grafana annotations, the card then is simply not rendered.

## EntitySwitch Example

```Typescript
<EntitySwitch>
  <EntitySwitch.Case if={isDashboardSelectorAvailable}>
    <Grid item xs={3}>
      <EntityGrafanaDashboardsCard />
    </Grid>
  </EntitySwitch.Case>
</EntitySwitch>
<EntitySwitch>
  <EntitySwitch.Case if={isAlertSelectorAvailable}>
    <Grid item xs={3}>
      <EntityGrafanaDashboardsCard />
    </Grid>
  </EntitySwitch.Case>
</EntitySwitch>
```
