### PR TITLE
(feat): display unifiedAlerting state

### DIFF
--- a/src/components/AlertsCard/AlertsCard.tsx
+++ b/src/components/AlertsCard/AlertsCard.tsx
@@ -92,7 +92,7 @@ const Alerts = ({entity, opts}: {entity: Entity, opts: AlertsCardOpts}) => {
   const unifiedAlertingEnabled = configApi.getOptionalBoolean('grafana.unifiedAlerting') || false;
   const alertSelector = unifiedAlertingEnabled ? alertSelectorFromEntity(entity) : tagSelectorFromEntity(entity);
 
-  const { value, loading, error } = useAsync(async () => await grafanaApi.alertsForSelector(alertSelector));
+  const { value, loading, error } = useAsync(async () => await grafanaApi.alertsForSelectors(alertSelector));
 
   if (loading) {
     return <Progress />;

--- a/src/components/AlertsCard/AlertsCard.tsx
+++ b/src/components/AlertsCard/AlertsCard.tsx
@@ -30,6 +30,7 @@ const AlertStatusBadge = ({ alert }: { alert: GrafanaAlert }) => {
 
   switch (alert.state) {
     case "ok":
+    case "Normal":
       statusElmt = <StatusOK />;
       break;
     case "paused":
@@ -37,9 +38,13 @@ const AlertStatusBadge = ({ alert }: { alert: GrafanaAlert }) => {
       break;
     case "no_data":
     case "pending":
+    case "Pending":
+    case "NoData":
       statusElmt = <StatusWarning />;
       break;
     case "alerting":
+    case "Alerting":
+    case "Error":
       statusElmt = <StatusError />;
       break;
     default:
@@ -125,7 +130,7 @@ export const AlertsCard = (opts?: AlertsCardOpts) => {
     return <MissingAnnotationEmptyState annotation={GRAFANA_ANNOTATION_ALERT_LABEL_SELECTOR} />;
   }
 
-  const finalOpts = {...opts, ...{showState: opts?.showState && !unifiedAlertingEnabled}};
+  const finalOpts = {...opts, ...{showState: opts?.showState}};
 
   return <Alerts entity={entity} opts={finalOpts} />;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,3 +33,8 @@ export {
   GRAFANA_ANNOTATION_TAG_SELECTOR,
   GRAFANA_ANNOTATION_OVERVIEW_DASHBOARD,
 } from './components/grafanaData';
+export { grafanaApiRef } from './api';
+export type {
+  Alert as GrafanaAlert, 
+  Dashboard as GrafanaDashboard,
+} from './types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,10 @@
   "include": ["src", "dev"],
   "compilerOptions": {
     "outDir": "dist-types",
-    "incremental": false
+    "incremental": false,
+    "lib": [
+      "es2020",
+      "dom"
+    ]
   }
 }


### PR DESCRIPTION
This is an extension for this PR: https://github.com/K-Phoen/backstage-plugin-grafana/pull/54
And fixes https://github.com/K-Phoen/backstage-plugin-grafana/issues/53

In this PR I'm extending a bit the API call, so that it can fetch not only one labelSelector, but multiple. So now it accepts a string or an array as input. Then, I created an aggregation function to analyze what is the state for each alert and return a final value.

As an example, if there are 3 alerts; 2 of them are `ok` but one is `firing`, then the final state will be `firing`.

The API extension is meant for some use cases where the API is called from another place in the UI (we are currently doing so, and doing a call per selector is really time consuming, especially when the request is always the same), therefore I also exported a couple types to allow other people to use this API internally.

To try it out, just enable the `unifiedAlerting` in your backstage instance, set the annotation and set the `showState` in the `EntityGrafanaAlertsCard` component to true.