### PR TITLE
Allow injecting additional dashboards to DashboardCard with hook

### DIFF
--- a/docs/dashboards-on-component-page.md
+++ b/docs/dashboards-on-component-page.md
@@ -69,3 +69,6 @@ Note that the `tags @> "my-service"` selector can be simplified as:
 annotations:
   grafana/dashboard-selector: my-service
 ```
+
+It's also possible to inject a hook to build other additional dashboards if that's required. For that, use the
+field `additionalDashboards` in the component `EntityGrafanaDashboardsCard`.

--- a/src/components/DashboardsCard/DashboardsCard.tsx
+++ b/src/components/DashboardsCard/DashboardsCard.tsx
@@ -66,7 +66,12 @@ export const DashboardsTable = ({entity, dashboards, opts}: {entity: Entity, das
 
 const Dashboards = ({entity, opts}: {entity: Entity, opts: DashboardCardOpts}) => {
   const grafanaApi = useApi(grafanaApiRef);
-  const { value, loading, error } = useAsync(async () => await grafanaApi.listDashboards(dashboardSelectorFromEntity(entity)));
+  const { value, loading, error} = useAsync(async () => {
+    const dashboards = await grafanaApi.listDashboards(dashboardSelectorFromEntity(entity));
+    if (opts?.additionalDashboards) {
+      dashboards.push(...(await opts.additionalDashboards(entity)))
+    }
+  });
 
   if (loading) {
     return <Progress />;
@@ -85,6 +90,7 @@ export type DashboardCardOpts = {
   pageSize?: number;
   sortable?: boolean;
   title?: string;
+  additionalDashboards?: (entity: Entity) => Dashboard[] | Promise<Dashboard[]>;
 };
 
 export const DashboardsCard = (opts?: DashboardCardOpts) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,3 +33,7 @@ export {
   GRAFANA_ANNOTATION_TAG_SELECTOR,
   GRAFANA_ANNOTATION_OVERVIEW_DASHBOARD,
 } from './components/grafanaData';
+export type {
+  Alert as GrafanaAlert,
+  Dashboard as GrafanaDashboard,
+} from './types'


### PR DESCRIPTION
In some cases, somebody might need to generate extra dashboards (in our case, some default ones). We've been using this customization internally for some time and it works well.

To use it, just simply set the `additionalDashboards` that is now available in the `EntityGrafanaDashboardsCard`.

Also, I've exported the 2 types used in this plugin since they might be useful here.