### PR TITLE
Always add folderTitle to dashboard object to avoid broken UI card

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -126,6 +126,7 @@ class Client {
       ...dashboard,
       url: domain + dashboard.url,
       folderUrl: domain + dashboard.folderUrl,
+      folderTitle: dashboard.folderTitle ?? '',
     }));
   }
 


### PR DESCRIPTION
If you use `folderTitle` dashboard selector in annotations, it might break the Dashboards card component with an error `identifier folderTitle does not exist`. 
The error happens if there is **at least one** dashboard in the response without a `folderTitle` field.

Example of annotation:
```yaml
metadata:
  annotations:
    grafana/dashboard-selector: folderTitle == 'Cool Folder Title'
```

Tested it with my project - works nicely!