### PR TITLE
chore(package.json): upgrades core-components to 0.13.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@backstage/catalog-model": "^1.2.1",
-    "@backstage/core-components": "^0.12.5",
+    "@backstage/core-components": "^0.13.5",
     "@backstage/core-plugin-api": "^1.5.0",
     "@backstage/plugin-catalog-react": "^1.4.0",
     "@material-ui/core": "^4.12.2",


### PR DESCRIPTION
Version 0.12.5 had a dependency which contained vulnerabilities. Because this is a **zero** release, I don't think Yarn/Npm lets us update automatically to 0.13.*, so I'm just opening this PR to update that core-component packages to the most updated version.